### PR TITLE
Playback

### DIFF
--- a/PLAYBACK_FEATURE.md
+++ b/PLAYBACK_FEATURE.md
@@ -1,0 +1,76 @@
+# Playback Selection Feature
+
+## Overview
+This feature allows you to start playback on your Plexamp devices using pre-configured playback URLs, similar to NFC tag functionality.
+
+## Configuration
+
+### Config File Location
+The playback configuration is stored at:
+- `~/.config/plexamp-tui/playback.json` (or `$XDG_CONFIG_HOME/plexamp-tui/playback.json`)
+
+### Config File Format
+```json
+{
+  "items": [
+    {
+      "name": "Display Name",
+      "url": "https://listen.plex.tv/player/playback/playMedia?address=YOUR_SERVER&machineIdentifier=YOUR_MACHINE_ID&key=/library/metadata/12345&type=music"
+    }
+  ]
+}
+```
+
+### Getting Playback URLs
+You can obtain playback URLs using the same method as the NFC project:
+1. Use the Plex web interface or app to find the content you want
+2. The URL format follows the pattern: `https://listen.plex.tv/player/playback/playMedia?...`
+3. Supported content types:
+   - **Tracks/Albums**: URLs containing `/library/metadata/`
+   - **Playlists**: URLs containing `/playlists/`
+   - **Stations**: URLs containing `/stations/`
+   - **Library Sections/Artists**: URLs containing `/sections/`
+
+### How It Works
+When you select a playback item:
+1. The app takes the `listen.plex.tv` URL from your config
+2. Replaces the domain with your selected server's IP (e.g., `192.168.1.100:32500`)
+3. Sends the playback request to your local Plexamp instance
+
+This bypasses the need for full authentication while still allowing you to start playback.
+
+## Usage
+
+The left panel can be toggled between two modes:
+- **Servers**: Choose which Plexamp instance to control
+- **Playlists**: Choose which content to start playing
+
+### Controls
+
+1. **Press `s` or `Tab`** to toggle the left panel between Servers and Playlists
+2. **Use ↑/↓** to navigate through items in the current panel
+3. **In Servers mode**: Press **Enter** to select a server
+4. **In Playlists mode**: Press **Enter or `p`** to start playback on the currently selected server
+
+The panel stays in the mode you selected - it won't automatically switch back after making a selection. This lets you quickly trigger multiple playlists without having to toggle back and forth.
+
+The right panel shows which mode the left panel is currently in ("Left Panel: Servers" or "Left Panel: Playlists").
+
+The app will display "Playback Started" or "Playback Failed" in the status based on the result.
+
+### Debug Mode
+
+To enable debug logging, run the app with the `--debug` flag:
+```bash
+./plexamp-tui --debug
+```
+
+Debug logs will be written to `~/.config/plexamp-tui/playback.log`
+
+## Example Config
+See `playback_example.json` for a template configuration file.
+
+## Notes
+- Make sure your playback URLs are valid and point to content in your Plex library
+- The selected server must be running and accessible
+- This feature works the same way as NFC tags - it's a local bypass that doesn't require full Plex authentication

--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ This application doesn't authenticate with Plex. Therefore it is limited to loca
 
 The main limitation is around starting playback. This seems to only be available through the cloud plex server. So you will need to start the play back through some other controller. IE the mobile app, web app, or my [NFC Controller](https://github.com/spiercey/plexamp-nfc-uart-python).
 
-Maybe one day I will update this with Authentication so we can view music and start.
+There is a local playback feature that allows you to start playback on your Plexamp devices using pre-configured playback URLs, similar to NFC tag functionality. See the [PLAYBACK_FEATURE.md](PLAYBACK_FEATURE.md) for more information on how to configure it.
+
+Maybe one day I will update this with Authentication so we can view music and start playback.
 
 ---
 

--- a/main.go
+++ b/main.go
@@ -141,14 +141,20 @@ type playbackTriggeredMsg struct {
 	err     error
 }
 
+// Global debug flag
+var debugMode bool
+
 // =====================
 // Main
 // =====================
 
 func main() {
-	// CLI flag for custom config path
+	// CLI flags
 	configFlag := flag.String("config", "", "Path to configuration file (optional)")
+	debugFlag := flag.Bool("debug", false, "Enable debug logging")
 	flag.Parse()
+
+	debugMode = *debugFlag
 
 	var cfg *Config
 	var cfgPath string

--- a/playback.go
+++ b/playback.go
@@ -1,0 +1,211 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/bubbles/list"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// =====================
+// Playback Config
+// =====================
+
+type PlaybackItem struct {
+	Name string `json:"name"`
+	URL  string `json:"url"`
+}
+
+type PlaybackConfig struct {
+	Items []PlaybackItem `json:"items"`
+}
+
+func playbackConfigPath() (string, error) {
+	base := os.Getenv("XDG_CONFIG_HOME")
+	if base == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		base = filepath.Join(home, ".config")
+	}
+	return filepath.Join(base, "plexamp-tui", "playback.json"), nil
+}
+
+func loadPlaybackConfig(path string) (*PlaybackConfig, error) {
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return nil, os.ErrNotExist
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	var cfg PlaybackConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil, err
+	}
+
+	return &cfg, nil
+}
+
+func saveDefaultPlaybackConfig(path string) error {
+	os.MkdirAll(filepath.Dir(path), 0755)
+
+	defaultCfg := PlaybackConfig{
+		Items: []PlaybackItem{
+			{
+				Name: "Example Station",
+				URL:  "https://listen.plex.tv/player/playback/playMedia?address=YOUR_SERVER&machineIdentifier=YOUR_MACHINE_ID&key=/library/metadata/12345&type=music",
+			},
+		},
+	}
+
+	data, _ := json.MarshalIndent(defaultCfg, "", "  ")
+	return os.WriteFile(path, data, 0644)
+}
+
+// =====================
+// Playback Popup Model
+// =====================
+
+type playbackPopup struct {
+	list     list.Model
+	items    []PlaybackItem
+	width    int
+	height   int
+	selected string
+}
+
+type playbackItem struct {
+	name string
+	url  string
+}
+
+func (i playbackItem) Title() string       { return i.name }
+func (i playbackItem) Description() string { return "" }
+func (i playbackItem) FilterValue() string { return i.name }
+
+func newPlaybackPopup(items []PlaybackItem, width, height int) playbackPopup {
+	var listItems []list.Item
+	for _, item := range items {
+		listItems = append(listItems, playbackItem{name: item.Name, url: item.URL})
+	}
+
+	l := list.New(listItems, list.NewDefaultDelegate(), width-4, height-6)
+	l.Title = "Select Playback"
+	l.SetShowHelp(false)
+	l.SetShowStatusBar(false)
+	l.SetFilteringEnabled(false)
+
+	return playbackPopup{
+		list:   l,
+		items:  items,
+		width:  width,
+		height: height,
+	}
+}
+
+func (p playbackPopup) Init() tea.Cmd {
+	return nil
+}
+
+func (p playbackPopup) Update(msg tea.Msg) (playbackPopup, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		keyStr := msg.String()
+		logDebug(fmt.Sprintf("Popup received key: '%s' (type: %d)", keyStr, msg.Type))
+		// Handle selection keys BEFORE passing to list
+		// Using 'p' for play since Enter isn't being received
+		if keyStr == "enter" || keyStr == "" || keyStr == "p" || msg.Type == tea.KeyEnter {
+			if selected, ok := p.list.SelectedItem().(playbackItem); ok {
+				logDebug(fmt.Sprintf("Selected item: %s -> %s", selected.name, selected.url))
+				p.selected = selected.url
+				return p, nil
+			} else {
+				logDebug("No item selected or type assertion failed")
+			}
+			// Don't pass to the list
+			return p, nil
+		}
+	}
+
+	// Pass other keys to the list for navigation
+	var cmd tea.Cmd
+	p.list, cmd = p.list.Update(msg)
+	return p, cmd
+}
+
+func (p playbackPopup) View() string {
+	border := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color("#00ffff")).
+		Padding(1, 2).
+		Width(p.width - 4).
+		Height(p.height - 4)
+
+	help := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("#8888ff")).
+		MarginTop(1).
+		Render("↑/↓ navigate • p to play • Esc cancel")
+
+	content := lipgloss.JoinVertical(lipgloss.Left, p.list.View(), help)
+	return border.Render(content)
+}
+
+// =====================
+// Playback Trigger
+// =====================
+
+func triggerPlayback(serverIP, fullURL string) error {
+	// Extract the path and query from the listen.plex.tv URL
+	// The URL format is: https://listen.plex.tv/player/playback/playMedia?uri=...
+	// We need to construct: http://serverIP:32500/player/playback/playMedia?uri=...
+	
+	// Remove the domain part and keep everything after it
+	localURL := strings.Replace(fullURL, "https://listen.plex.tv", fmt.Sprintf("http://%s:32500", serverIP), 1)
+	localURL = strings.Replace(localURL, "http://listen.plex.tv", fmt.Sprintf("http://%s:32500", serverIP), 1)
+
+	// Log to file for debugging
+	logDebug(fmt.Sprintf("Triggering playback to: %s", localURL))
+	
+	resp, err := http.Get(localURL)
+	if err != nil {
+		logDebug(fmt.Sprintf("Request error: %v", err))
+		return fmt.Errorf("failed to connect to %s: %w", serverIP, err)
+	}
+	defer resp.Body.Close()
+
+	logDebug(fmt.Sprintf("Response status: %d", resp.StatusCode))
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("server returned status %d", resp.StatusCode)
+	}
+
+	return nil
+}
+
+func logDebug(msg string) {
+	// Log to a file in the config directory for debugging
+	logPath, err := playbackConfigPath()
+	if err != nil {
+		return
+	}
+	logFile := filepath.Join(filepath.Dir(logPath), "playback.log")
+	
+	f, err := os.OpenFile(logFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	
+	timestamp := time.Now().Format("2006-01-02 15:04:05")
+	fmt.Fprintf(f, "[%s] %s\n", timestamp, msg)
+}

--- a/playback.go
+++ b/playback.go
@@ -154,7 +154,7 @@ func (p playbackPopup) View() string {
 	help := lipgloss.NewStyle().
 		Foreground(lipgloss.Color("#8888ff")).
 		MarginTop(1).
-		Render("↑/↓ navigate • p to play • Esc cancel")
+		Render("↑/↓ navigate • Enter or p to play • Esc cancel")
 
 	content := lipgloss.JoinVertical(lipgloss.Left, p.list.View(), help)
 	return border.Render(content)

--- a/playback.go
+++ b/playback.go
@@ -193,6 +193,11 @@ func triggerPlayback(serverIP, fullURL string) error {
 }
 
 func logDebug(msg string) {
+	// Only log if debug mode is enabled
+	if !debugMode {
+		return
+	}
+	
 	// Log to a file in the config directory for debugging
 	logPath, err := playbackConfigPath()
 	if err != nil {

--- a/playback_example.json
+++ b/playback_example.json
@@ -1,0 +1,16 @@
+{
+  "items": [
+    {
+      "name": "Screaming Females Radio",
+      "url": "https://listen.plex.tv/player/playback/playMedia?address=YOUR_SERVER&machineIdentifier=YOUR_MACHINE_ID&key=/library/sections/1/stations/12345&type=music"
+    },
+    {
+      "name": "Favorite Playlist",
+      "url": "https://listen.plex.tv/player/playback/playMedia?address=YOUR_SERVER&machineIdentifier=YOUR_MACHINE_ID&key=/playlists/67890&type=music"
+    },
+    {
+      "name": "Album Example",
+      "url": "https://listen.plex.tv/player/playback/playMedia?address=YOUR_SERVER&machineIdentifier=YOUR_MACHINE_ID&key=/library/metadata/11111&type=music"
+    }
+  ]
+}


### PR DESCRIPTION
The app currently only supports controlling what is currently playing on the plexamp server. IE if you already have a playlist started you can control it. 

This PR adds a work around for the plex server auth to allow us to start playback from pre-defined playback urls. 

I currently get these from my NFC tags. 

If you can retrieve the playback urls from the plexamp app. You can add them to your local configuration file for selection. EG:

`~/.config/plexamp-tui/playback.json`

```
{
  "items": [
    {
      "name": "All Artist,
      "url": "https://listen.plex.tv/player/playback/playMedia?uri=server%3A%2F%uri%2Fcom.plexapp.plugins.library%2Flibrary%2Fsections%2F15%2Fall%3Fartist."
    }
  ]
}
```

This will allow you to select this playback media and send directly to the selected server from within the TUI. 

You can currently switch between server and playback selection with `tab` or `s` keys.