### PR TITLE
Plex server library discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,19 +14,6 @@ It allows you to select a Plexamp server, view the currently playing track, play
 * Displays current track, playback state, progress, and volume.
 * Control playback: play/pause, next, previous.
 * Control volume: increase or decrease in 5% increments.
-* Shows a warning when using the default config (127.0.0.1).
-
----
-
-## Limitations
-
-This application doesn't authenticate with Plex. Therefore it is limited to local control only. Plex doesn't provide any detailed API on local control so features are limited to what has been found/discovered about the local API. 
-
-The main limitation is around starting playback. This seems to only be available through the cloud plex server. So you will need to start the play back through some other controller. IE the mobile app, web app, or my [NFC Controller](https://github.com/spiercey/plexamp-nfc-uart-python).
-
-There is a local playback feature that allows you to start playback on your Plexamp devices using pre-configured playback URLs, similar to NFC tag functionality. See the [PLAYBACK_FEATURE.md](PLAYBACK_FEATURE.md) for more information on how to configure it.
-
-Maybe one day I will update this with Authentication so we can view music and start playback.
 
 ---
 
@@ -45,11 +32,25 @@ cd plexamp-tui
 go build -o plexamp-tui
 ```
 
-3. Run the program:
+3. Run the program with auth flag to authenticate with Plex:
+
+```bash
+./plexamp-tui --auth
+```
+
+4. Follow the instructions to authenticate with Plex.
+
+5. Run the program normally:
 
 ```bash
 ./plexamp-tui
 ```
+
+Use the Server Selector with 6 to select your server
+Use the Playback Selector with 7 to select your playback device. 
+
+
+Use 1, 2 or 3 to switch between Artist, Albums and Playlists to play. 
 
 ---
 
@@ -63,23 +64,8 @@ By default, the program will create a configuration file at:
 ~/.config/plexamp-tui/config.json
 ```
 
-with the default Plexamp instance:
+Once in the TUI, you can select your server and playback device using the Server Selector by pressing 6 and Playback selector by pressing 7.
 
-```json
-{
-  "instances": ["127.0.0.1"]
-}
-```
-
-> ⚠️ **Warning:** Using `127.0.0.1` as the default server may not find any running Plexamp instances.
-> Update the config file with your server IP(s) to connect properly.
-
-**Editing from the TUI:** You can also add or edit servers directly from within the app:
-- Press **`a`** to add a new server
-- Press **`e`** to edit the selected server
-- Changes are saved automatically to the config file
-
-See the `config.example.json` file for how you can reference your servers. 
 
 ### Custom Config Path
 
@@ -88,37 +74,7 @@ You can specify a custom config file with:
 ```bash
 ./plexamp-tui --config /path/to/config.json
 ```
-
-### Config Format
-
-The JSON file should contain an `instances` array with your Plexamp server IPs or hostnames:
-
-```json
-{
-  "instances": [
-    "192.168.1.100",
-    "192.168.1.101"
-  ]
-}
-```
-
 ---
-
-## Usage
-
-### Navigation
-
-* **↑ / ↓** – Navigate the list of Plexamp instances.
-* **Enter** – Select a server.
-* **p** – Play / Pause.
-* **n** – Next track.
-* **b** – Previous track.
-* **[ / -** – Decrease volume by 5%.
-* **] / +** – Increase volume by 5%.
-* **q / Ctrl+C** – Quit the program.
-
----
-
 
 ## License
 

--- a/controls.go
+++ b/controls.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/charmbracelet/bubbletea"
+import tea "github.com/charmbracelet/bubbletea"
 
 // handleControl processes common playback control key presses
 // Returns the command to execute and a boolean indicating if a control was handled
@@ -23,6 +23,9 @@ func (m *model) handleControl(key string) (tea.Cmd, bool) {
 
 	case "h": // Toggle shuffle
 		return m.toggleShuffle(), true
+
+	case "tab": // Cycle library
+		return m.cycleLibrary(), true
 
 	default:
 		return nil, false

--- a/controls.go
+++ b/controls.go
@@ -42,11 +42,76 @@ func (m *model) handleControl(key string) (tea.Cmd, bool) {
 
 	case "tab": // Cycle library
 		return m.cycleLibrary(), true
-		
+
 	case "r": // Refresh current panel
 		return m.refreshCurrentPanel(), true
+
+	case "1": // Open artist browse
+		return m.openArtistBrowser()
+
+	case "2": // Open album browse
+		return m.openAlbumBrowser()
+
+	case "3": // Open playlist browse
+		return m.openPlaylistBrowser()
+
+	case "6": // Open server browse
+		return m.openServerBrowser()
+
+	case "7": // Open player browse
+		return m.openPlayerBrowser()
 
 	default:
 		return nil, false
 	}
+}
+
+func (m *model) openArtistBrowser() (tea.Cmd, bool) {
+	if m.plexAuthenticated && m.config != nil {
+		m.initArtistBrowse()
+		return m.fetchArtistsCmd(), true
+	} else {
+		m.status = "Plex authentication required (run with --auth)"
+	}
+	return nil, false
+}
+
+func (m *model) openAlbumBrowser() (tea.Cmd, bool) {
+	if m.plexAuthenticated && m.config != nil {
+		m.initAlbumBrowse()
+		return m.fetchAlbumsCmd(), true
+	} else {
+		m.status = "Plex authentication required (run with --auth)"
+	}
+	return nil, false
+}
+
+func (m *model) openPlaylistBrowser() (tea.Cmd, bool) {
+	if m.plexAuthenticated && m.config != nil {
+		m.initPlaylistBrowse()
+		return m.fetchPlaylistsCmd(), true
+	} else {
+		m.status = "Plex authentication required (run with --auth)"
+	}
+	return nil, false
+}
+
+func (m *model) openServerBrowser() (tea.Cmd, bool) {
+	if m.plexAuthenticated && m.config != nil {
+		m.initServerBrowse()
+		return m.fetchServersCmd(), true
+	} else {
+		m.status = "Plex authentication required (run with --auth)"
+	}
+	return nil, false
+}
+
+func (m *model) openPlayerBrowser() (tea.Cmd, bool) {
+	if m.plexAuthenticated && m.config != nil {
+		m.initPlayerBrowse()
+		return m.fetchPlayersCmd(), true
+	} else {
+		m.status = "Plex authentication required (run with --auth)"
+	}
+	return nil, false
 }

--- a/controls.go
+++ b/controls.go
@@ -4,6 +4,22 @@ import tea "github.com/charmbracelet/bubbletea"
 
 // handleControl processes common playback control key presses
 // Returns the command to execute and a boolean indicating if a control was handled
+// refreshCurrentPanel returns a command that refreshes the current panel based on the panel mode
+func (m *model) refreshCurrentPanel() tea.Cmd {
+	switch m.panelMode {
+	case "plex-artists":
+		return m.fetchArtistsCmd()
+	case "plex-albums":
+		return m.fetchAlbumsCmd()
+	case "plex-playlists":
+		return m.fetchPlaylistsCmd()
+	default:
+		return nil
+	}
+}
+
+// handleControl processes common playback control key presses
+// Returns the command to execute and a boolean indicating if a control was handled
 func (m *model) handleControl(key string) (tea.Cmd, bool) {
 	switch key {
 	case " ", "p": // Space or 'p' for play/pause
@@ -26,6 +42,9 @@ func (m *model) handleControl(key string) (tea.Cmd, bool) {
 
 	case "tab": // Cycle library
 		return m.cycleLibrary(), true
+		
+	case "r": // Refresh current panel
+		return m.refreshCurrentPanel(), true
 
 	default:
 		return nil, false

--- a/library_select_view.go
+++ b/library_select_view.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+func (m model) libraryControlsView() string {
+	value := lipgloss.NewStyle().Foreground(lipgloss.Color("#00ffcc")).Bold(true)
+
+	body := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#ffaa00")).Render("Library Selection") + "\n\n"
+
+	for _, library := range m.config.PlexLibraries {
+		if library.Key == m.config.PlexLibraryID {
+			body += fmt.Sprintf("%s\n", value.Render(library.Title))
+		} else {
+			body += fmt.Sprintf("%s\n", library.Title)
+		}
+	}
+
+	return body
+}

--- a/main.go
+++ b/main.go
@@ -252,7 +252,7 @@ func main() {
 		}
 	}
 	playbackList := list.New(playbackItems, list.NewDefaultDelegate(), 0, 0)
-	playbackList.Title = "Select Playback"
+	playbackList.Title = "Favorites"
 
 	m := model{
 		playbackList:      playbackList,
@@ -488,56 +488,6 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		switch key {
 		case "ctrl+c", "q":
 			return m, tea.Quit
-
-		case "3":
-			// Open artist browse (if authenticated)
-			if m.plexAuthenticated && m.config != nil {
-				m.initArtistBrowse()
-				return m, m.fetchArtistsCmd()
-			} else {
-				m.status = "Plex authentication required (run with --auth)"
-			}
-			return m, nil
-
-		case "4":
-			// Open album browse (if authenticated)
-			if m.plexAuthenticated && m.config != nil {
-				m.initAlbumBrowse()
-				return m, m.fetchAlbumsCmd()
-			} else {
-				m.status = "Plex authentication required (run with --auth)"
-			}
-			return m, nil
-
-		case "5":
-			// Open playlist browse (if authenticated)
-			if m.plexAuthenticated && m.config != nil {
-				m.initPlaylistBrowse()
-				return m, m.fetchPlaylistsCmd()
-			} else {
-				m.status = "Plex authentication required (run with --auth)"
-			}
-			return m, nil
-
-		case "6":
-			// Open server browse (if authenticated)
-			if m.plexAuthenticated && m.config != nil {
-				m.initServerBrowse()
-				return m, m.fetchServersCmd()
-			} else {
-				m.status = "Plex authentication required (run with --auth)"
-			}
-			return m, nil
-
-		case "7":
-			// Open player browse (if authenticated)
-			if m.plexAuthenticated && m.config != nil {
-				m.initPlayerBrowse()
-				return m, m.fetchPlayersCmd()
-			} else {
-				m.status = "Plex authentication required (run with --auth)"
-			}
-			return m, nil
 
 		default:
 			// Try the common controls

--- a/main.go
+++ b/main.go
@@ -871,6 +871,27 @@ func (m *model) toggleShuffle() tea.Cmd {
 	return nil
 }
 
+// will use the config to cycle through the library options, it will check the current selected library and increment to the next one, if it is the last one it will go back to the first one
+func (m *model) cycleLibrary() tea.Cmd {
+	currentLibraryKey := m.config.PlexLibraryID
+
+	for i := range m.config.PlexLibraries {
+		if m.config.PlexLibraries[i].Key == currentLibraryKey {
+			if i == len(m.config.PlexLibraries)-1 {
+				m.config.PlexLibraryID = m.config.PlexLibraries[0].Key
+				m.config.PlexLibraryName = m.config.PlexLibraries[0].Title
+				m.saveServerConfig()
+			} else {
+				m.config.PlexLibraryID = m.config.PlexLibraries[i+1].Key
+				m.config.PlexLibraryName = m.config.PlexLibraries[i+1].Title
+				m.saveServerConfig()
+			}
+			break
+		}
+	}
+	return nil
+}
+
 // =====================
 // Plexamp control logic
 // =====================

--- a/main.go
+++ b/main.go
@@ -694,8 +694,9 @@ func (m model) View() string {
 
 	// Right side has two stacked panels
 	playbackPanel := border.Width(m.width/2 - 2).Render(m.playbackStatusView())
+	libraryPanel := border.Width(m.width/2 - 2).Render(m.libraryControlsView())
 	controlsPanel := border.Width(m.width/2 - 2).Render(m.appControlsView())
-	rightSide := lipgloss.JoinVertical(lipgloss.Left, playbackPanel, controlsPanel)
+	rightSide := lipgloss.JoinVertical(lipgloss.Left, playbackPanel, libraryPanel, controlsPanel)
 
 	content := lipgloss.JoinHorizontal(lipgloss.Top, leftPanel, rightSide)
 	return lipgloss.JoinVertical(lipgloss.Left, title, content)

--- a/main.go
+++ b/main.go
@@ -880,13 +880,13 @@ func (m *model) cycleLibrary() tea.Cmd {
 			if i == len(m.config.PlexLibraries)-1 {
 				m.config.PlexLibraryID = m.config.PlexLibraries[0].Key
 				m.config.PlexLibraryName = m.config.PlexLibraries[0].Title
-				m.saveServerConfig()
 			} else {
 				m.config.PlexLibraryID = m.config.PlexLibraries[i+1].Key
 				m.config.PlexLibraryName = m.config.PlexLibraries[i+1].Title
-				m.saveServerConfig()
 			}
-			break
+			m.saveServerConfig()
+			// Return a command that will refresh the current panel
+			return m.refreshCurrentPanel()
 		}
 	}
 	return nil

--- a/plex-cloud-api.go
+++ b/plex-cloud-api.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"encoding/xml"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+//curl "https://plex.tv/api/resources?includeHttps=1&includeRelay=1&X-Plex-Token=<token>"
+
+const (
+	plexCloudBaseURL = "https://plex.tv"
+)
+
+type PlexDeviceInfo struct {
+	Name                 string           `xml:"name,attr"`
+	Product              string           `xml:"product,attr"`
+	ProductVersion       string           `xml:"productVersion,attr"`
+	Platform             string           `xml:"platform,attr"`
+	PlatformVersion      string           `xml:"platformVersion,attr"`
+	Device               string           `xml:"device,attr"`
+	ClientIdentifier     string           `xml:"clientIdentifier,attr"`
+	CreatedAt            string           `xml:"createdAt,attr"`
+	LastSeenAt           string           `xml:"lastSeenAt,attr"`
+	Provides             string           `xml:"provides,attr"`
+	Owned                string           `xml:"owned,attr"`
+	SearchEnabled        string           `xml:"searchEnabled,attr"`
+	PublicAddress        string           `xml:"publicAddress,attr"`
+	PublicAddressMatches string           `xml:"publicAddressMatches,attr"`
+	Presence             string           `xml:"presence,attr"`
+	Connections          []PlexConnection `xml:"Connection"`
+}
+
+type PlexConnection struct {
+	Protocol string `xml:"protocol,attr"`
+	Address  string `xml:"address,attr"`
+	Port     string `xml:"port,attr"`
+	URI      string `xml:"uri,attr"`
+	Local    string `xml:"local,attr"`
+	Relay    string `xml:"relay,attr"`
+}
+
+type PlexDeviceContainer struct {
+	XMLName xml.Name         `xml:"MediaContainer"`
+	Size    int              `xml:"size,attr"`
+	Devices []PlexDeviceInfo `xml:"Device"`
+}
+
+func GetPlexServerInformation() ([]PlexDeviceInfo, error) {
+	token := getPlexToken()
+	urlStr := fmt.Sprintf("%s/api/resources?includeHttps=1&includeRelay=1&X-Plex-Token=%s", plexCloudBaseURL, token)
+
+	resp, err := http.Get(urlStr)
+	if err != nil {
+		logDebug(fmt.Sprintf("Request error: %v", err))
+		return nil, fmt.Errorf("failed to connect to %s: %w", plexCloudBaseURL, err)
+	}
+	defer resp.Body.Close()
+
+	logDebug(fmt.Sprintf("Response status: %d", resp.StatusCode))
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		return nil, fmt.Errorf("server returned status %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	var container PlexDeviceContainer
+	if err := xml.Unmarshal(body, &container); err != nil {
+		return nil, fmt.Errorf("failed to parse XML: %w", err)
+	}
+
+	return container.Devices, nil
+}

--- a/plex_album_browse.go
+++ b/plex_album_browse.go
@@ -77,7 +77,6 @@ func (m *model) initAlbumBrowse() {
 	m.albumList = list.New(items, delegate, 0, 0)
 	m.albumList.Title = "Plex Albums"
 	m.albumList.SetShowFilter(true)
-	m.albumList.SetShowStatusBar(false)
 	m.albumList.SetFilteringEnabled(true)
 	m.albumList.Styles.Title = titleStyle
 	m.albumList.Styles.PaginationStyle = paginationStyle

--- a/plex_album_browse.go
+++ b/plex_album_browse.go
@@ -36,6 +36,10 @@ func (i albumItem) FilterValue() string {
 // fetchAlbumsCmd fetches albums from the Plex server
 func (m *model) fetchAlbumsCmd() tea.Cmd {
 	logDebug("Fetching albums...")
+	// ✅ Reapply sizing
+	footerHeight := 3 // or dynamically measure your footer
+	availableHeight := m.height - footerHeight - 5
+	m.albumList.SetSize(m.width/2-4, availableHeight)
 	if m.config == nil {
 		return func() tea.Msg {
 			return albumsFetchedMsg{err: fmt.Errorf("no config available")}
@@ -195,6 +199,11 @@ func (m *model) handleAlbumBrowseUpdate(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.status = fmt.Sprintf("Loaded %d albums", len(msg.albums))
 		logDebug(fmt.Sprintf("Updated model with new album list. List has %d items", m.albumList.VisibleItems()))
+
+		// ✅ Reapply sizing
+		footerHeight := 3 // or dynamically measure your footer
+		availableHeight := m.height - footerHeight - 5
+		m.albumList.SetSize(m.width/2-4, availableHeight)
 
 		// Force a redraw
 		return m, tea.Batch(tea.ClearScreen, func() tea.Msg { return nil })

--- a/plex_artist_browse.go
+++ b/plex_artist_browse.go
@@ -29,6 +29,10 @@ type artistPlaybackMsg struct {
 // fetchArtistsCmd fetches artists from the Plex server
 func (m *model) fetchArtistsCmd() tea.Cmd {
 	logDebug("Fetching artists...")
+	// ✅ Reapply sizing
+	footerHeight := 3 // or dynamically measure your footer
+	availableHeight := m.height - footerHeight - 5
+	m.artistList.SetSize(m.width/2-4, availableHeight)
 	if m.config == nil {
 		return func() tea.Msg {
 			return artistsFetchedMsg{err: fmt.Errorf("no config available")}
@@ -117,7 +121,7 @@ func (m *model) initArtistBrowse() {
 	// Create a new default delegate with custom styling
 	delegate := list.NewDefaultDelegate()
 	delegate.ShowDescription = false // Don't show description
-	
+
 	m.artistList = list.New(items, delegate, 0, 0)
 	m.artistList.Title = "Plex Artists"
 	m.artistList.SetShowFilter(true)
@@ -212,15 +216,15 @@ func (m *model) handleArtistBrowseUpdate(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Preserve the current filter state
 		filterState := m.artistList.FilterState()
 		filterValue := m.artistList.FilterValue()
-		
+
 		// Create a new default delegate with custom styling
 		delegate := list.NewDefaultDelegate()
 		delegate.ShowDescription = false // Don't show description
-		
+
 		// Create new list with existing items
 		m.artistList.SetItems(items)
 		m.artistList.ResetSelected()
-		
+
 		// Restore filter state if there was one
 		if filterState == list.Filtering {
 			m.artistList.ResetFilter()
@@ -263,15 +267,15 @@ type artistItem struct {
 func (i artistItem) Title() string       { return i.title }
 func (i artistItem) Description() string { return "" } // No description needed
 // FilterValue implements list.Item
-func (i artistItem) FilterValue() string { 
+func (i artistItem) FilterValue() string {
 	// Return the title in lowercase for case-insensitive matching
-	return i.title 
+	return i.title
 }
 
 // Custom styles for the list
 var (
-	titleStyle = lipgloss.NewStyle().MarginLeft(2)
-	itemStyle = lipgloss.NewStyle().PaddingLeft(4)
-	helpStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("240")).Margin(1, 0, 0, 2)
+	titleStyle      = lipgloss.NewStyle().MarginLeft(2)
+	itemStyle       = lipgloss.NewStyle().PaddingLeft(4)
+	helpStyle       = lipgloss.NewStyle().Foreground(lipgloss.Color("240")).Margin(1, 0, 0, 2)
 	paginationStyle = list.DefaultStyles().PaginationStyle.PaddingLeft(4)
 )

--- a/plex_player_browse.go
+++ b/plex_player_browse.go
@@ -82,7 +82,6 @@ func (m *model) initPlayerBrowse() {
 	m.playerList = list.New(items, delegate, 0, 0)
 	m.playerList.Title = "Plex Players"
 	m.playerList.SetShowFilter(true)
-	m.playerList.SetShowStatusBar(false)
 	m.playerList.SetFilteringEnabled(true)
 	m.playerList.Styles.Title = titleStyle
 	m.playerList.Styles.PaginationStyle = paginationStyle

--- a/plex_player_browse.go
+++ b/plex_player_browse.go
@@ -1,0 +1,220 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/charmbracelet/bubbles/list"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+type playerSelectMsg struct {
+	success bool
+	err     error
+	player  playerItem
+}
+
+// playerItem represents a player in the list
+type playerItem struct {
+	title            string
+	clientIdentifier string
+	address          string
+	local            string
+	port             string
+}
+
+// playersFetchedMsg is a message containing fetched players
+type playersFetchedMsg struct {
+	players []PlexConnectionSelection
+	err     error
+}
+
+// Title returns the playlist title
+func (i playerItem) Title() string {
+	return fmt.Sprintf("%s - %s", i.title, i.address)
+}
+
+// Description returns the playlist description (empty for now)
+func (i playerItem) Description() string { return "" }
+
+// FilterValue implements list.Item
+func (i playerItem) FilterValue() string {
+	return i.title + " " + i.clientIdentifier
+}
+
+// fetchPlayersCmd fetches players from the Plex server
+func (m *model) fetchPlayersCmd() tea.Cmd {
+	logDebug("Fetching players...")
+	if m.config == nil {
+		return func() tea.Msg {
+			return playersFetchedMsg{err: fmt.Errorf("no config available")}
+		}
+	}
+
+	token := getPlexToken()
+	if token == "" {
+		return func() tea.Msg {
+			return playersFetchedMsg{err: fmt.Errorf("no Plex token found - run with --auth flag")}
+		}
+	}
+
+	return func() tea.Msg {
+		players, err := getPlexPlayers()
+		return playersFetchedMsg{players: players, err: err}
+	}
+}
+
+// initPlayerBrowse creates a new player browser
+func (m *model) initPlayerBrowse() {
+	m.panelMode = "plex-players"
+	m.status = "Loading players..."
+
+	// Create a new default delegate with custom styling
+	delegate := list.NewDefaultDelegate()
+	delegate.ShowDescription = false
+
+	items := []list.Item{playerItem{title: "Loading players..."}}
+
+	// Create the list with empty items for now
+	m.playerList = list.New(items, delegate, 0, 0)
+	m.playerList.Title = "Plex Players"
+	m.playerList.SetShowFilter(true)
+	m.playerList.SetShowStatusBar(false)
+	m.playerList.SetFilteringEnabled(true)
+	m.playerList.Styles.Title = titleStyle
+	m.playerList.Styles.PaginationStyle = paginationStyle
+	m.playerList.Styles.HelpStyle = helpStyle
+	if m.width > 0 && m.height > 0 {
+		m.playerList.SetSize(m.width/2-4, m.height-4)
+	}
+}
+func (m *model) selectPlayerCmd(player playerItem) tea.Cmd {
+	if m.config == nil {
+		return func() tea.Msg {
+			return playerSelectMsg{success: false, err: fmt.Errorf("no config available")}
+		}
+	}
+
+	// Return a message with the player information
+	return func() tea.Msg {
+		return playerSelectMsg{
+			success: true,
+			player:  player,
+		}
+	}
+}
+
+func (m *model) handlePlayerBrowseUpdate(msg tea.Msg) (tea.Model, tea.Cmd) {
+	logDebug(fmt.Sprintf("handlePlayerBrowseUpdate received message: %T", msg))
+
+	// If we're in filtering mode, let the list handle the input
+	if m.playerList.FilterState() == list.Filtering {
+		var cmd tea.Cmd
+		m.playerList, cmd = m.playerList.Update(msg)
+		return m, cmd
+	}
+
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		key := msg.String()
+
+		switch key {
+		case "esc", "q":
+			// Return to playback panel
+			m.panelMode = "playback"
+			m.status = ""
+			return m, nil
+
+		case "enter":
+			// Select Server
+			if selected, ok := m.playerList.SelectedItem().(playerItem); ok {
+				logDebug(fmt.Sprintf("Selecting player: %s (clientIdentifier: %s)", selected.title, selected.clientIdentifier))
+				m.lastCommand = fmt.Sprintf("Selecting %s", selected.title)
+				return m, m.selectPlayerCmd(selected)
+			}
+			return m, nil
+
+		case "R":
+			// Refresh player list
+			m.status = "Refreshing players..."
+			return m, m.fetchPlayersCmd()
+
+		default:
+
+			// Otherwise try the common controls
+			if cmd, handled := m.handleControl(key); handled {
+				return m, cmd
+			}
+		}
+
+	case playersFetchedMsg:
+		logDebug(fmt.Sprintf("playersFetchedMsg received with %d players, error: %v", len(msg.players), msg.err))
+		if msg.err != nil {
+			errMsg := fmt.Sprintf("Error fetching players: %v", msg.err)
+			m.status = errMsg
+			logDebug(errMsg)
+			return m, nil
+		}
+
+		// Convert servers to list items
+		var items []list.Item
+		for i, player := range msg.players {
+			if i < 5 { // Only log first 5 servers to avoid log spam
+				logDebug(fmt.Sprintf("Adding player %d: %s (ratingKey: %s)", i+1, player.Name, player.ClientIdentifier))
+			}
+			items = append(items, playerItem{
+				title:            player.Name,
+				clientIdentifier: player.ClientIdentifier,
+				address:          player.Address,
+				local:            player.Local,
+				port:             player.Port,
+			})
+		}
+
+		logDebug(fmt.Sprintf("Creating new list with %d items", len(items)))
+		// Create a new list with the fetched items
+		// Preserve the current filter state
+		filterState := m.playerList.FilterState()
+		filterValue := m.playerList.FilterValue()
+
+		// Create a new default delegate with custom styling
+		delegate := list.NewDefaultDelegate()
+		delegate.ShowDescription = false // Don't show description
+
+		// Create new list with existing items
+		m.playerList.SetItems(items)
+		m.playerList.ResetSelected()
+
+		// Restore filter state if there was one
+		if filterState == list.Filtering {
+			m.playerList.ResetFilter()
+			m.playerList.FilterInput.SetValue(filterValue)
+		}
+		m.status = fmt.Sprintf("Loaded %d players", len(msg.players))
+		logDebug(fmt.Sprintf("Updated model with new player list. List has %d items", m.playerList.VisibleItems()))
+
+		// Force a redraw
+		return m, tea.Batch(tea.ClearScreen, func() tea.Msg { return nil })
+
+	case playerSelectMsg:
+		if msg.success {
+			m.lastCommand = "Player Selected"
+			m.status = "Player selected successfully"
+		} else {
+			m.lastCommand = "Player Selection Failed"
+			m.status = fmt.Sprintf("Player selection error: %v", msg.err)
+		}
+		// Return the updated model and no command
+		return m, nil
+	}
+
+	// Update the player list and get the command
+	var listCmd tea.Cmd
+	m.playerList, listCmd = m.playerList.Update(msg)
+	// Return the current model (as a pointer) and the command
+	return m, listCmd
+}
+
+// View renders the player browser
+func (m *model) ViewPlayer() string {
+	return m.playerList.View() + "\n" + m.status
+}

--- a/plex_player_browse.go
+++ b/plex_player_browse.go
@@ -44,6 +44,10 @@ func (i playerItem) FilterValue() string {
 // fetchPlayersCmd fetches players from the Plex server
 func (m *model) fetchPlayersCmd() tea.Cmd {
 	logDebug("Fetching players...")
+	// ✅ Reapply sizing
+	footerHeight := 3 // or dynamically measure your footer
+	availableHeight := m.height - footerHeight - 5
+	m.playerList.SetSize(m.width/2-4, availableHeight)
 	if m.config == nil {
 		return func() tea.Msg {
 			return playersFetchedMsg{err: fmt.Errorf("no config available")}

--- a/plex_playlist_browse.go
+++ b/plex_playlist_browse.go
@@ -42,6 +42,10 @@ func (i playlistItem) FilterValue() string {
 // fetchPlaylistsCmd fetches playlists from the Plex server
 func (m *model) fetchPlaylistsCmd() tea.Cmd {
 	logDebug("Fetching playlists...")
+	// ✅ Reapply sizing
+	footerHeight := 3 // or dynamically measure your footer
+	availableHeight := m.height - footerHeight - 5
+	m.playlistList.SetSize(m.width/2-4, availableHeight)
 	if m.config == nil {
 		return func() tea.Msg {
 			return playlistsFetchedMsg{err: fmt.Errorf("no config available")}

--- a/plex_playlist_browse.go
+++ b/plex_playlist_browse.go
@@ -82,7 +82,6 @@ func (m *model) initPlaylistBrowse() {
 	m.playlistList = list.New(items, delegate, 0, 0)
 	m.playlistList.Title = "Plex Playlists"
 	m.playlistList.SetShowFilter(true)
-	m.playlistList.SetShowStatusBar(false)
 	m.playlistList.SetFilteringEnabled(true)
 	m.playlistList.Styles.Title = titleStyle
 	m.playlistList.Styles.PaginationStyle = paginationStyle

--- a/plex_server_browse.go
+++ b/plex_server_browse.go
@@ -45,6 +45,10 @@ func (i serverItem) FilterValue() string {
 // fetchServersCmd fetches servers from the Plex server
 func (m *model) fetchServersCmd() tea.Cmd {
 	logDebug("Fetching servers...")
+	// ✅ Reapply sizing
+	footerHeight := 3 // or dynamically measure your footer
+	availableHeight := m.height - footerHeight - 5
+	m.serverList.SetSize(m.width/2-4, availableHeight)
 	if m.config == nil {
 		return func() tea.Msg {
 			return serversFetchedMsg{err: fmt.Errorf("no config available")}

--- a/plex_server_browse.go
+++ b/plex_server_browse.go
@@ -1,0 +1,234 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/charmbracelet/bubbles/list"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// serverItem represents a server in the list
+type serverItem struct {
+	title            string
+	clientIdentifier string
+	address          string
+	local            string
+	port             string
+}
+
+// serversFetchedMsg is a message containing fetched servers
+type serversFetchedMsg struct {
+	servers []PlexConnectionSelection
+	err     error
+}
+
+type serverSelectMsg struct {
+	success   bool
+	err       error
+	server    serverItem
+	libraries []PlexLibrary
+}
+
+// Title returns the playlist title
+func (i serverItem) Title() string {
+	return fmt.Sprintf("%s - %s", i.title, i.address)
+}
+
+// Description returns the playlist description (empty for now)
+func (i serverItem) Description() string { return "" }
+
+// FilterValue implements list.Item
+func (i serverItem) FilterValue() string {
+	return i.title + " " + i.clientIdentifier
+}
+
+// fetchServersCmd fetches servers from the Plex server
+func (m *model) fetchServersCmd() tea.Cmd {
+	logDebug("Fetching servers...")
+	if m.config == nil {
+		return func() tea.Msg {
+			return serversFetchedMsg{err: fmt.Errorf("no config available")}
+		}
+	}
+
+	token := getPlexToken()
+	if token == "" {
+		return func() tea.Msg {
+			return serversFetchedMsg{err: fmt.Errorf("no Plex token found - run with --auth flag")}
+		}
+	}
+
+	return func() tea.Msg {
+		servers, err := GetPlexServerInformation()
+		return serversFetchedMsg{servers: servers, err: err}
+	}
+}
+
+// initServerBrowse creates a new server browser
+func (m *model) initServerBrowse() {
+	m.panelMode = "plex-servers"
+	m.status = "Loading servers..."
+
+	// Create a new default delegate with custom styling
+	delegate := list.NewDefaultDelegate()
+	delegate.ShowDescription = false
+
+	items := []list.Item{serverItem{title: "Loading servers..."}}
+
+	// Create the list with empty items for now
+	m.serverList = list.New(items, delegate, 0, 0)
+	m.serverList.Title = "Plex Servers"
+	m.serverList.SetShowFilter(true)
+	m.serverList.SetShowStatusBar(false)
+	m.serverList.SetFilteringEnabled(true)
+	m.serverList.Styles.Title = titleStyle
+	m.serverList.Styles.PaginationStyle = paginationStyle
+	m.serverList.Styles.HelpStyle = helpStyle
+	if m.width > 0 && m.height > 0 {
+		m.serverList.SetSize(m.width/2-4, m.height-4)
+	}
+}
+func (m *model) selectServerCmd(server serverItem) tea.Cmd {
+	if m.selected == "" {
+		return func() tea.Msg {
+			return serverSelectMsg{success: false, err: fmt.Errorf("no server selected")}
+		}
+	}
+
+	if m.config == nil {
+		return func() tea.Msg {
+			return serverSelectMsg{success: false, err: fmt.Errorf("no config available")}
+		}
+	}
+
+	return func() tea.Msg {
+
+		libraries, err := FetchLibrary(fmt.Sprintf("%s:%s", server.address, server.port), getPlexToken())
+
+		if err != nil {
+			logDebug(fmt.Sprintf("Error fetching libraries: %v", err))
+		}
+
+		// When a server is selected we will write the serverId and serverAddress:port to the config file and save it to disk
+		// m.config.ServerID = server.clientIdentifier
+		// m.config.PlexServerAddr = server.address + ":" + server.port
+		// m.saveServerConfig()
+		return serverSelectMsg{success: true, server: server, libraries: libraries}
+	}
+}
+
+func (m *model) handleServerBrowseUpdate(msg tea.Msg) (tea.Model, tea.Cmd) {
+	logDebug(fmt.Sprintf("handleServerBrowseUpdate received message: %T", msg))
+
+	// If we're in filtering mode, let the list handle the input
+	if m.serverList.FilterState() == list.Filtering {
+		var cmd tea.Cmd
+		m.serverList, cmd = m.serverList.Update(msg)
+		return m, cmd
+	}
+
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		key := msg.String()
+
+		switch key {
+		case "esc", "q":
+			// Return to playback panel
+			m.panelMode = "playback"
+			m.status = ""
+			return m, nil
+
+		case "enter":
+			// Select Server
+			if selected, ok := m.serverList.SelectedItem().(serverItem); ok {
+				logDebug(fmt.Sprintf("Selecting server: %s (clientIdentifier: %s)", selected.title, selected.clientIdentifier))
+				m.lastCommand = fmt.Sprintf("Selecting %s", selected.title)
+				return m, m.selectServerCmd(selected)
+			}
+			return m, nil
+
+		case "R":
+			// Refresh server list
+			m.status = "Refreshing servers..."
+			return m, m.fetchServersCmd()
+
+		default:
+
+			// Otherwise try the common controls
+			if cmd, handled := m.handleControl(key); handled {
+				return m, cmd
+			}
+		}
+
+	case serversFetchedMsg:
+		logDebug(fmt.Sprintf("serversFetchedMsg received with %d servers, error: %v", len(msg.servers), msg.err))
+		if msg.err != nil {
+			errMsg := fmt.Sprintf("Error fetching servers: %v", msg.err)
+			m.status = errMsg
+			logDebug(errMsg)
+			return m, nil
+		}
+
+		// Convert servers to list items
+		var items []list.Item
+		for i, server := range msg.servers {
+			if i < 5 { // Only log first 5 servers to avoid log spam
+				logDebug(fmt.Sprintf("Adding server %d: %s (ratingKey: %s)", i+1, server.Name, server.ClientIdentifier))
+			}
+			items = append(items, serverItem{
+				title:            server.Name,
+				clientIdentifier: server.ClientIdentifier,
+				address:          server.Address,
+				local:            server.Local,
+				port:             server.Port,
+			})
+		}
+
+		logDebug(fmt.Sprintf("Creating new list with %d items", len(items)))
+		// Create a new list with the fetched items
+		// Preserve the current filter state
+		filterState := m.serverList.FilterState()
+		filterValue := m.serverList.FilterValue()
+
+		// Create a new default delegate with custom styling
+		delegate := list.NewDefaultDelegate()
+		delegate.ShowDescription = false // Don't show description
+
+		// Create new list with existing items
+		m.serverList.SetItems(items)
+		m.serverList.ResetSelected()
+
+		// Restore filter state if there was one
+		if filterState == list.Filtering {
+			m.serverList.ResetFilter()
+			m.serverList.FilterInput.SetValue(filterValue)
+		}
+		m.status = fmt.Sprintf("Loaded %d servers", len(msg.servers))
+		logDebug(fmt.Sprintf("Updated model with new server list. List has %d items", m.serverList.VisibleItems()))
+
+		// Force a redraw
+		return m, tea.Batch(tea.ClearScreen, func() tea.Msg { return nil })
+
+	case serverSelectMsg:
+		if msg.success {
+			m.lastCommand = "Server Selected"
+			m.status = "Server selected successfully"
+		} else {
+			m.lastCommand = "Server Selection Failed"
+			m.status = fmt.Sprintf("Server selection error: %v", msg.err)
+		}
+		// Return the updated model and no command
+		return m, nil
+	}
+
+	// Update the server list and get the command
+	var listCmd tea.Cmd
+	m.serverList, listCmd = m.serverList.Update(msg)
+	// Return the current model (as a pointer) and the command
+	return m, listCmd
+}
+
+// View renders the server browser
+func (m *model) ViewServer() string {
+	return m.serverList.View() + "\n" + m.status
+}

--- a/plex_server_browse.go
+++ b/plex_server_browse.go
@@ -83,7 +83,6 @@ func (m *model) initServerBrowse() {
 	m.serverList = list.New(items, delegate, 0, 0)
 	m.serverList.Title = "Plex Servers"
 	m.serverList.SetShowFilter(true)
-	m.serverList.SetShowStatusBar(false)
 	m.serverList.SetFilteringEnabled(true)
 	m.serverList.Styles.Title = titleStyle
 	m.serverList.Styles.PaginationStyle = paginationStyle


### PR DESCRIPTION
The app previously worked by manually setting configurations for servers/playback urls/etc.

While this worked fine it really wasn't usable for most people, nor was it easy to access new music that wasn't previously configured. 

This change switches this app from a local only config based controller to one that is fully integrated with Plex. 

You will now need to authenticate with plex wherein you can select your server, playback device, and browse and select Artists/Albums/Playlist to play. All retrieved dynamically from the server rather than hardcoded config files. 


You can still use the config files to set the information if for some reason you don't want to authenticate with plex. But it works much better when you do .