### PR TITLE
Plex server select bug

### DIFF
--- a/main.go
+++ b/main.go
@@ -327,6 +327,14 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.config.PlexLibraries = msg.libraries
 
 			found := false
+			if len(msg.libraries) == 0 {
+				logDebug("No libraries found on this server")
+				m.panelMode = "playback"
+				m.lastCommand = "Server Selected Failed, No Libraries"
+				m.status = "No libraries found on this server"
+				return m, nil
+			}
+
 			//check if new library list has our configured library
 			for _, lib := range msg.libraries {
 				if lib.Title == m.config.PlexLibraryName {
@@ -336,10 +344,12 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 
 			if !found {
+				logDebug("Current Library not found on this server, using first library")
 				m.config.PlexLibraryName = msg.libraries[0].Title
 				m.config.PlexLibraryID = msg.libraries[0].Key
 			}
 
+			logDebug(fmt.Sprintf("Saving server config: %v", m.config))
 			m.saveServerConfig()
 			m.lastCommand = "Server Selected"
 			m.status = ""

--- a/plex_library.go
+++ b/plex_library.go
@@ -271,5 +271,7 @@ func FetchLibrary(serverAddr, token string) ([]PlexLibrary, error) {
 		}
 	}
 
+	logDebug(fmt.Sprintf("Fetched %d artist libraries", len(libraries)))
+
 	return libraries, nil
 }

--- a/plex_server_browse.go
+++ b/plex_server_browse.go
@@ -107,6 +107,7 @@ func (m *model) selectServerCmd(server serverItem) tea.Cmd {
 	return func() tea.Msg {
 
 		libraries, err := FetchLibrary(fmt.Sprintf("%s:%s", server.address, server.port), getPlexToken())
+		logDebug(fmt.Sprintf("Fetched libraries: %v", libraries))
 
 		if err != nil {
 			logDebug(fmt.Sprintf("Error fetching libraries: %v", err))


### PR DESCRIPTION
Currently if you select a server with no "artist" based libraries the app will crash at runtime trying to select the first library. 

This handles that crash instead of failing out. 