### PR TITLE
Favorites managment

### DIFF
--- a/internal/config/favorites.go
+++ b/internal/config/favorites.go
@@ -10,7 +10,7 @@ import (
 // FavoriteItem represents a single favorite item
 type FavoriteItem struct {
 	Name        string `json:"name"`
-	Type        string `json:"type"` // "artist", "album", "track", "playlist", "station"
+	Type        string `json:"type"` // "artist", "album", "playlist"
 	MetadataKey string `json:"key"`
 }
 
@@ -61,7 +61,7 @@ func (fm *FavoritesManager) Load() (*Favorites, error) {
 
 // Save saves the favorites to disk
 func (fm *FavoritesManager) Save(favs *Favorites) error {
-	if err := os.MkdirAll(filepath.Dir(fm.favoritesPath), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(fm.favoritesPath), 0o755); err != nil {
 		return err
 	}
 
@@ -71,7 +71,7 @@ func (fm *FavoritesManager) Save(favs *Favorites) error {
 	}
 
 	tempPath := fm.favoritesPath + ".tmp"
-	if err := os.WriteFile(tempPath, data, 0644); err != nil {
+	if err := os.WriteFile(tempPath, data, 0o644); err != nil {
 		return err
 	}
 

--- a/internal/ui/app_control_view.go
+++ b/internal/ui/app_control_view.go
@@ -1,0 +1,26 @@
+package ui
+
+import (
+	"fmt"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+func (m model) appControlsView() string {
+	body := ""
+
+	if m.usingDefaultCfg {
+		body += lipgloss.NewStyle().Foreground(lipgloss.Color("#ff5555")).Render(
+			"⚠️ Using default config\n\n")
+	}
+
+	plexControls := ""
+	if m.plexAuthenticated {
+		plexControls = "\n  1 Artists  2 Albums  3 Playlists"
+	}
+
+	controlsText := fmt.Sprintf("Controls:\n  ↑/↓ navigate\n  Enter select\n  [p / space] Play/Pause\n  n Next\n  b Previous\n  +/- Volume %s\n  q Quit", plexControls)
+	controls := lipgloss.NewStyle().MarginTop(1).Foreground(lipgloss.Color("#8888ff")).Render(controlsText)
+
+	return fmt.Sprintf("%s%s", body, controls)
+}

--- a/internal/ui/edit.go
+++ b/internal/ui/edit.go
@@ -47,7 +47,6 @@ func (m *model) initEditMode(editType string, index int) {
 			typeItem("Artist"),
 			typeItem("Album"),
 			typeItem("Playlist"),
-			typeItem("Station"),
 		}
 
 		// Initialize the list with default settings
@@ -65,8 +64,6 @@ func (m *model) initEditMode(editType string, index int) {
 				typeSelect.Select(1)
 			case "playlist":
 				typeSelect.Select(2)
-			case "station":
-				typeSelect.Select(3)
 			}
 		}
 
@@ -209,8 +206,6 @@ func (m *model) savePlaybackEdit() error {
 			selectedType = "album"
 		case "Playlist":
 			selectedType = "playlist"
-		case "Station":
-			selectedType = "station"
 		}
 	}
 
@@ -255,7 +250,7 @@ func (m *model) savePlaybackEdit() error {
 	// Update the list
 	var items []list.Item
 	for _, pb := range cfg.Items {
-		items = append(items, item(pb.Name))
+		items = append(items, item{pb.Name, pb.Type, pb.MetadataKey})
 	}
 	m.playbackList.SetItems(items)
 	m.playbackConfig = cfg
@@ -298,7 +293,7 @@ func (m model) editPanelView() string {
 		content += typeLabel + "\n"
 
 		// Custom type selection display
-		typeOptions := []string{"Artist", "Album", "Playlist", "Station"}
+		typeOptions := []string{"Artist", "Album", "Playlist"}
 		typeContent := ""
 		for i, option := range typeOptions {
 			itemStyle := lipgloss.NewStyle().PaddingLeft(2)
@@ -342,12 +337,19 @@ func (m *model) deletePlaybackItem(index int) error {
 	// Update the list
 	var items []list.Item
 	for _, pb := range m.playbackConfig.Items {
-		items = append(items, item(pb.Name))
+		items = append(items, item{Name: pb.Name, Type: pb.Type, MetadataKey: pb.MetadataKey})
 	}
 	m.playbackList.SetItems(items)
 
 	// Save to file
 	favsManager.Save(m.playbackConfig)
 
+	return nil
+}
+
+func (m *model) savePlaybackItem(name string, k string, t string) error {
+	m.playbackConfig.Items = append(m.playbackConfig.Items, config.FavoriteItem{Name: name, MetadataKey: k, Type: t})
+	m.playbackList.SetItems(append(m.playbackList.Items(), item{Name: name, MetadataKey: k, Type: t}))
+	favsManager.Save(m.playbackConfig)
 	return nil
 }

--- a/internal/ui/favorites.go
+++ b/internal/ui/favorites.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"fmt"
+
 	"plexamp-tui/internal/config"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -10,6 +11,25 @@ import (
 // =====================
 // Playback Trigger
 // =====================
+
+func (m *model) triggerFavoriteRadioPlayback(item config.FavoriteItem) tea.Cmd {
+	log.Debug(fmt.Sprintf("Triggering radio playback for %s", item.Name))
+	if m.selected == "" {
+		return func() tea.Msg {
+			return artistPlaybackMsg{success: false, err: fmt.Errorf("no server selected")}
+		}
+	}
+
+	if m.config == nil {
+		return func() tea.Msg {
+			return artistPlaybackMsg{success: false, err: fmt.Errorf("no config available")}
+		}
+	}
+
+	m.lastCommand = fmt.Sprintf("Playing radio for %s", item.Name)
+
+	return func() tea.Msg { return m.playArtistRadioCmd(item.MetadataKey)() }
+}
 
 func (m *model) triggerFavoritePlayback(item config.FavoriteItem) tea.Cmd {
 	log.Debug(fmt.Sprintf("Triggering playback for %s", item.Name))
@@ -25,6 +45,7 @@ func (m *model) triggerFavoritePlayback(item config.FavoriteItem) tea.Cmd {
 		}
 	}
 
+	m.lastCommand = fmt.Sprintf("Playing %s", item.Name)
 	switch item.Type {
 	case "artist":
 		log.Debug(fmt.Sprintf("Playing artist: %s", item.Name))
@@ -35,13 +56,34 @@ func (m *model) triggerFavoritePlayback(item config.FavoriteItem) tea.Cmd {
 	case "playlist":
 		log.Debug(fmt.Sprintf("Playing playlist: %s", item.Name))
 		return func() tea.Msg { return m.playPlaylistCmd(item.MetadataKey)() }
-	case "station":
-		log.Debug(fmt.Sprintf("Playing station: %s", item.Name))
-		return func() tea.Msg { return m.playArtistRadioCmd(item.MetadataKey)() }
 	default:
 		log.Debug(fmt.Sprintf("Unknown type: %s", item.Type))
 		return func() tea.Msg {
 			return artistPlaybackMsg{success: false, err: fmt.Errorf("unknown type: %s", item.Type)}
 		}
 	}
+}
+
+func (m *model) addRemoveFavorite(name string, k string, t string) (tea.Model, tea.Cmd) {
+	log.Debug(fmt.Sprintf("Toggling favorite for %s", name))
+	favSet := m.getCurrentFavSet()
+	if _, exists := favSet[k]; exists {
+		log.Debug(fmt.Sprintf("Removing favorite: %s", name))
+		// Delete selected playback item
+		index := m.playbackList.Index()
+		m.deletePlaybackItem(index)
+		return m, nil
+	}
+	log.Debug(fmt.Sprintf("Adding favorite: %s", name))
+	m.savePlaybackItem(name, k, t)
+	return m, nil
+}
+
+func (m *model) getCurrentFavSet() map[string]struct{} {
+	favSet := make(map[string]struct{})
+	for _, pItem := range m.playbackList.Items() {
+		pItem := pItem.(item)
+		favSet[pItem.GetMetadataKey()] = struct{}{}
+	}
+	return favSet
 }

--- a/internal/ui/footer.go
+++ b/internal/ui/footer.go
@@ -1,0 +1,82 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// footerView renders the application footer
+func (m model) footerView() string {
+	header := lipgloss.NewStyle().Foreground(lipgloss.Color("#ffaa00"))
+	value := lipgloss.NewStyle().Foreground(lipgloss.Color("#00ffcc")).Bold(true)
+	info := lipgloss.NewStyle().Foreground(lipgloss.Color("#8888ff"))
+	footerStyle := lipgloss.NewStyle().
+		BorderStyle(lipgloss.RoundedBorder()).
+		BorderTop(true).
+		BorderForeground(lipgloss.Color("#00ffff")).
+		Padding(0, 1)
+
+	var shuffleValue string
+	if m.shuffle {
+		shuffleValue = lipgloss.NewStyle().Foreground(lipgloss.Color("#00ff00")).Bold(true).Render("ON")
+	} else {
+		shuffleValue = lipgloss.NewStyle().Foreground(lipgloss.Color("#ff5555")).Bold(true).Render("OFF")
+	}
+	// --- Left side (your existing info)
+	left := ""
+	left += fmt.Sprintf("%s %s: %s \n", header.Render("Shuffle"), info.Render("(h)"), shuffleValue)
+	if len(m.config.PlexLibraries) > 0 {
+		left += fmt.Sprintf("%s %s: ", header.Render("Library"), info.Render("(Tab)"))
+		for _, library := range m.config.PlexLibraries {
+			if library.Key == m.config.PlexLibraryID {
+				left += fmt.Sprintf("%s | ", value.Render(library.Title))
+			} else {
+				left += fmt.Sprintf("%s | ", library.Title)
+			}
+		}
+		left = strings.TrimSuffix(left, "| ")
+		left += "\n"
+	}
+
+	left += fmt.Sprintf("%s %s: %s | ", header.Render("Server"), info.Render("(6)"), value.Render(m.config.PlexServerName))
+	left += fmt.Sprintf("%s %s: %s", header.Render("Player"), info.Render("(7)"), value.Render(m.config.SelectedPlayerName))
+
+	// --- Right side (new)
+	// Example: replace with whatever info you want (track, status, etc.)
+	var right string
+	if m.plexAuthenticated {
+		right = fmt.Sprintf("%s: %s ", header.Render("Authenticated"), value.Render("✓"))
+	} else {
+		right = fmt.Sprintf("%s: %s ", header.Render("Authenticated"), value.Render("✗"))
+	}
+
+	right += fmt.Sprintf("\n%s: %s ", header.Render("Last Command"), value.Render(m.lastCommand))
+
+	// --- Combine left and right
+	leftLines := strings.Split(left, "\n")
+	rightLines := strings.Split(right, "\n")
+
+	var combinedLines []string
+	maxLines := max(len(leftLines), len(rightLines))
+
+	for i := 0; i < maxLines; i++ {
+		var l, r string
+		if i < len(leftLines) {
+			l = leftLines[i]
+		}
+		if i < len(rightLines) {
+			r = rightLines[i]
+		}
+
+		padding := m.width - lipgloss.Width(l) - lipgloss.Width(r) - 4 // adjust for borders/padding
+		if padding < 1 {
+			padding = 1
+		}
+		line := l + strings.Repeat(" ", padding) + r
+		combinedLines = append(combinedLines, line)
+	}
+
+	return footerStyle.Width(m.width - 2).Render(strings.Join(combinedLines, "\n"))
+}

--- a/internal/ui/playback_status_view.go
+++ b/internal/ui/playback_status_view.go
@@ -1,0 +1,147 @@
+package ui
+
+import (
+	"fmt"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+func (m model) playbackStatusView() string {
+	info := lipgloss.NewStyle().Foreground(lipgloss.Color("#aaaaaa"))
+	value := lipgloss.NewStyle().Foreground(lipgloss.Color("#00ffcc")).Bold(true)
+
+	state := "⏸️ Paused"
+	if m.isPlaying {
+		state = "▶️ Playing"
+	}
+
+	current := "None"
+	if m.currentTrack != "" {
+		current = m.currentTrack
+	}
+
+	elapsed := m.currentPosition()
+	progress := formatTime(elapsed) + " / " + formatTime(m.durationMs)
+	bar := progressBar(elapsed, m.durationMs, 20)
+
+	body := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#ffaa00")).Render("Now Playing") + "\n\n"
+	body += fmt.Sprintf(
+		"%s: %s\n%s: %s\n%s: %s\n%s: %d\n",
+		info.Render("State"), value.Render(state),
+		info.Render("Track"), value.Render(current),
+		info.Render("Progress"), value.Render(bar+"  "+progress),
+		info.Render("Volume"), m.volume,
+	)
+
+	return body
+}
+
+// =====================
+// Playback Control Methods
+// =====================
+
+// togglePlayback toggles between play and pause
+func (m *model) togglePlayback() tea.Cmd {
+	if m.isPlaying {
+		m.sendCommand("playback/pause")
+		m.isPlaying = false
+		m.lastCommand = "Pause"
+	} else {
+		m.sendCommand("playback/play")
+		m.isPlaying = true
+		m.lastCommand = "Play"
+	}
+	return m.pollTimeline()
+}
+
+// nextTrack skips to the next track
+func (m *model) nextTrack() tea.Cmd {
+	m.sendCommand("playback/skipNext")
+	m.lastCommand = "Next"
+	return m.pollTimeline()
+}
+
+// previousTrack goes to the previous track
+func (m *model) previousTrack() tea.Cmd {
+	m.sendCommand("playback/skipPrevious")
+	m.lastCommand = "Previous"
+	return m.pollTimeline()
+}
+
+// adjustVolume changes the volume by the specified delta (range: -100 to +100)
+func (m *model) adjustVolume(delta int) tea.Cmd {
+	newVol := m.volume + delta
+	if newVol < 0 {
+		newVol = 0
+	} else if newVol > 100 {
+		newVol = 100
+	}
+
+	// Use setVolume to handle the actual volume change
+	m.setVolume(newVol)
+
+	// Update the status message
+	m.lastCommand = fmt.Sprintf("Volume %d%%", newVol)
+
+	// Return a command to update the timeline
+	return m.pollTimeline()
+}
+
+// seek seeks the current track by the specified number of seconds
+func (m *model) seek(seconds int) tea.Cmd {
+	// Calculate the new position in milliseconds
+	newPos := m.positionMs + (seconds * 1000)
+
+	// Ensure the position is within bounds
+	if newPos < 0 {
+		newPos = 0
+	} else if m.durationMs > 0 && newPos > m.durationMs {
+		newPos = m.durationMs
+	}
+
+	// Send the seek command with absolute position
+	m.sendCommand(fmt.Sprintf("playback/seekTo?time=%d", newPos))
+	m.lastCommand = fmt.Sprintf("Seek to %s", formatTime(newPos))
+
+	// Update the position immediately for better UX
+	m.positionMs = newPos
+	m.lastUpdate = time.Now()
+
+	return m.pollTimeline()
+}
+
+// toggleShuffle toggles shuffle mode
+func (m *model) toggleShuffle() tea.Cmd {
+	m.shuffle = !m.shuffle
+	if m.shuffle {
+		m.sendCommand("playback/shuffle/on")
+		m.lastCommand = "Shuffle ON"
+	} else {
+		m.sendCommand("playback/shuffle/off")
+		m.lastCommand = "Shuffle OFF"
+	}
+	return nil
+}
+
+// will use the config to cycle through the library options, it will check the current selected library and increment to the next one, if it is the last one it will go back to the first one
+func (m *model) cycleLibrary() tea.Cmd {
+	currentLibraryKey := m.config.PlexLibraryID
+
+	for i := range m.config.PlexLibraries {
+		if m.config.PlexLibraries[i].Key == currentLibraryKey {
+			if i == len(m.config.PlexLibraries)-1 {
+				m.config.PlexLibraryID = m.config.PlexLibraries[0].Key
+				m.config.PlexLibraryName = m.config.PlexLibraries[0].Title
+			} else {
+				m.config.PlexLibraryID = m.config.PlexLibraries[i+1].Key
+				m.config.PlexLibraryName = m.config.PlexLibraries[i+1].Title
+			}
+			cfgManager.Save(m.config)
+			// Return a command that will refresh the current panel
+			return m.refreshCurrentPanel()
+		}
+	}
+	return nil
+}

--- a/internal/ui/plex_album_browse.go
+++ b/internal/ui/plex_album_browse.go
@@ -2,6 +2,8 @@ package ui
 
 import (
 	"fmt"
+	"strings"
+
 	"plexamp-tui/internal/plex"
 
 	"github.com/charmbracelet/bubbles/list"
@@ -23,6 +25,9 @@ type albumItem struct {
 
 // Title returns the album title
 func (i albumItem) Title() string {
+	if strings.HasSuffix(i.title, " ★") {
+		return fmt.Sprintf("%s - %s (%s) ★", strings.TrimSuffix(i.title, " ★"), i.artist, i.year)
+	}
 	return fmt.Sprintf("%s - %s (%s)", i.title, i.artist, i.year)
 }
 
@@ -32,6 +37,15 @@ func (i albumItem) Description() string { return "" }
 // FilterValue implements list.Item
 func (i albumItem) FilterValue() string {
 	return i.title + " " + i.artist
+}
+
+func (a *albumItem) ToggleFavorite() {
+	// If title already has a star, remove it
+	if strings.HasSuffix(a.title, " ★") {
+		a.title = strings.TrimSuffix(a.title, " ★")
+	} else {
+		a.title = fmt.Sprintf("%s ★", a.title)
+	}
 }
 
 // fetchAlbumsCmd fetches albums from the Plex server
@@ -86,6 +100,7 @@ func (m *model) initAlbumBrowse() {
 		m.albumList.SetSize(m.width/2-4, m.height-4)
 	}
 }
+
 func (m *model) playAlbumCmd(ratingKey string) tea.Cmd {
 	if m.selected == "" {
 		return func() tea.Msg {
@@ -133,6 +148,21 @@ func (m *model) handleAlbumBrowseUpdate(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.status = ""
 			return m, nil
 
+		case "f":
+			// add or remove selected artist from favorites (playback list)
+			if selected, ok := m.albumList.SelectedItem().(albumItem); ok {
+				log.Debug(fmt.Sprintf("Toggling favorite for album: %s (ratingKey: %s)", selected.title, selected.ratingKey))
+				m.lastCommand = fmt.Sprintf("Toggling favorite for %s", selected.title)
+
+				_, cmd := m.addRemoveFavorite(selected.title, selected.ratingKey, "album")
+				selected.ToggleFavorite()
+
+				// Update the item in the list
+				m.albumList.SetItem(m.albumList.Index(), selected)
+
+				return m, cmd
+			}
+
 		case "enter":
 			// Play selected album's tracks
 			if selected, ok := m.albumList.SelectedItem().(albumItem); ok {
@@ -145,6 +175,7 @@ func (m *model) handleAlbumBrowseUpdate(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "R":
 			// Refresh album list
 			m.status = "Refreshing albums..."
+			m.lastCommand = "Refreshing album list"
 			return m, m.fetchAlbumsCmd()
 
 		default:
@@ -164,14 +195,29 @@ func (m *model) handleAlbumBrowseUpdate(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 
+		favSet := make(map[string]struct{})
+		for _, pItem := range m.playbackList.Items() {
+			pItem := pItem.(item)
+			favSet[pItem.GetMetadataKey()] = struct{}{}
+		}
 		// Convert albums to list items
 		var items []list.Item
 		for i, album := range msg.albums {
 			if i < 5 { // Only log first 5 albums to avoid log spam
 				log.Debug(fmt.Sprintf("Adding album %d: %s (ratingKey: %s)", i+1, album.Title, album.RatingKey))
 			}
+
+			fav := false
+			if _, exists := favSet[album.RatingKey]; exists {
+				fav = true
+			}
+			title := album.Title
+			if fav {
+				title = fmt.Sprintf("%s ★", album.Title)
+			}
+
 			items = append(items, albumItem{
-				title:     album.Title,
+				title:     title,
 				artist:    album.ParentTitle,
 				year:      album.Year,
 				ratingKey: album.RatingKey,

--- a/internal/ui/plex_album_browse.go
+++ b/internal/ui/plex_album_browse.go
@@ -6,6 +6,7 @@ import (
 
 	"plexamp-tui/internal/plex"
 
+	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
 )
@@ -96,6 +97,26 @@ func (m *model) initAlbumBrowse() {
 	m.albumList.Styles.Title = titleStyle
 	m.albumList.Styles.PaginationStyle = paginationStyle
 	m.albumList.Styles.HelpStyle = helpStyle
+	m.albumList.AdditionalShortHelpKeys = func() []key.Binding {
+		return []key.Binding{
+			key.NewBinding(
+				key.WithKeys("f"),
+				key.WithHelp("f", "favs"),
+			),
+		}
+	}
+	m.albumList.AdditionalFullHelpKeys = func() []key.Binding {
+		return []key.Binding{
+			key.NewBinding(
+				key.WithKeys("f"),
+				key.WithHelp("f", "Add/Remove from Favorites"),
+			),
+			key.NewBinding(
+				key.WithKeys("R"),
+				key.WithHelp("R", "Refresh Albums"),
+			),
+		}
+	}
 	if m.width > 0 && m.height > 0 {
 		m.albumList.SetSize(m.width/2-4, m.height-4)
 	}

--- a/internal/ui/plex_artist_browse.go
+++ b/internal/ui/plex_artist_browse.go
@@ -6,6 +6,7 @@ import (
 
 	"plexamp-tui/internal/plex"
 
+	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -132,6 +133,30 @@ func (m *model) initArtistBrowse() {
 	m.artistList.Styles.Title = titleStyle
 	m.artistList.Styles.PaginationStyle = paginationStyle
 	m.artistList.Styles.HelpStyle = helpStyle
+	m.artistList.AdditionalShortHelpKeys = func() []key.Binding {
+		return []key.Binding{
+			key.NewBinding(
+				key.WithKeys("f"),
+				key.WithHelp("f", "favs"),
+			),
+		}
+	}
+	m.artistList.AdditionalFullHelpKeys = func() []key.Binding {
+		return []key.Binding{
+			key.NewBinding(
+				key.WithKeys("f"),
+				key.WithHelp("f", "Add/Remove from Favorites"),
+			),
+			key.NewBinding(
+				key.WithKeys("r"),
+				key.WithHelp("r", "Play Radio"),
+			),
+			key.NewBinding(
+				key.WithKeys("R"),
+				key.WithHelp("R", "Refresh Artists"),
+			),
+		}
+	}
 
 	if m.width > 0 && m.height > 0 {
 		m.artistList.SetSize(m.width/2-4, m.height-4)

--- a/internal/ui/plex_playlist_browse.go
+++ b/internal/ui/plex_playlist_browse.go
@@ -2,6 +2,8 @@ package ui
 
 import (
 	"fmt"
+	"strings"
+
 	"plexamp-tui/internal/plex"
 
 	"github.com/charmbracelet/bubbles/list"
@@ -29,6 +31,9 @@ type playlistsFetchedMsg struct {
 
 // Title returns the playlist title
 func (i playlistItem) Title() string {
+	if strings.HasSuffix(i.title, " ★") {
+		return fmt.Sprintf("%s - %s (%s) ★", strings.TrimSuffix(i.title, " ★"), i.artist, i.year)
+	}
 	return fmt.Sprintf("%s - %s (%s)", i.title, i.artist, i.year)
 }
 
@@ -38,6 +43,15 @@ func (i playlistItem) Description() string { return "" }
 // FilterValue implements list.Item
 func (i playlistItem) FilterValue() string {
 	return i.title + " " + i.artist
+}
+
+func (p *playlistItem) ToggleFavorite() {
+	// If title already has a star, remove it
+	if strings.HasSuffix(p.title, " ★") {
+		p.title = strings.TrimSuffix(p.title, " ★")
+	} else {
+		p.title = fmt.Sprintf("%s ★", p.title)
+	}
 }
 
 // fetchPlaylistsCmd fetches playlists from the Plex server
@@ -91,6 +105,7 @@ func (m *model) initPlaylistBrowse() {
 		m.playlistList.SetSize(m.width/2-4, m.height-4)
 	}
 }
+
 func (m *model) playPlaylistCmd(ratingKey string) tea.Cmd {
 	if m.selected == "" {
 		return func() tea.Msg {
@@ -147,6 +162,18 @@ func (m *model) handlePlaylistBrowseUpdate(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			return m, nil
 
+		case "f":
+			// add or remove selected artist from favorites (playback list)
+			if selected, ok := m.playlistList.SelectedItem().(playlistItem); ok {
+				log.Debug(fmt.Sprintf("Toggling favorite for playlist: %s (ratingKey: %s)", selected.title, selected.ratingKey))
+				m.lastCommand = fmt.Sprintf("Toggling favorite for %s", selected.title)
+				_, cmd := m.addRemoveFavorite(selected.title, selected.ratingKey, "playlist")
+				selected.ToggleFavorite()
+				// Update the item in the list
+				m.playlistList.SetItem(m.playlistList.Index(), selected)
+				return m, cmd
+			}
+
 		case "R":
 			// Refresh album list
 			m.status = "Refreshing albums..."
@@ -169,14 +196,30 @@ func (m *model) handlePlaylistBrowseUpdate(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 
+		favSet := make(map[string]struct{})
+		for _, pItem := range m.playbackList.Items() {
+			pItem := pItem.(item)
+			favSet[pItem.GetMetadataKey()] = struct{}{}
+		}
+
 		// Convert playlists to list items
 		var items []list.Item
 		for i, playlist := range msg.playlists {
 			if i < 5 { // Only log first 5 playlists to avoid log spam
 				log.Debug(fmt.Sprintf("Adding playlist %d: %s (ratingKey: %s)", i+1, playlist.Title, playlist.RatingKey))
 			}
+
+			fav := false
+			if _, exists := favSet[playlist.RatingKey]; exists {
+				fav = true
+			}
+			title := playlist.Title
+			if fav {
+				title = fmt.Sprintf("%s ★", playlist.Title)
+			}
+
 			items = append(items, playlistItem{
-				title:     playlist.Title,
+				title:     title,
 				ratingKey: playlist.RatingKey,
 			})
 		}

--- a/internal/ui/plex_playlist_browse.go
+++ b/internal/ui/plex_playlist_browse.go
@@ -6,6 +6,7 @@ import (
 
 	"plexamp-tui/internal/plex"
 
+	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
 )
@@ -101,6 +102,27 @@ func (m *model) initPlaylistBrowse() {
 	m.playlistList.Styles.Title = titleStyle
 	m.playlistList.Styles.PaginationStyle = paginationStyle
 	m.playlistList.Styles.HelpStyle = helpStyle
+
+	m.playlistList.AdditionalShortHelpKeys = func() []key.Binding {
+		return []key.Binding{
+			key.NewBinding(
+				key.WithKeys("f"),
+				key.WithHelp("f", "favs"),
+			),
+		}
+	}
+	m.playlistList.AdditionalFullHelpKeys = func() []key.Binding {
+		return []key.Binding{
+			key.NewBinding(
+				key.WithKeys("f"),
+				key.WithHelp("f", "Add/Remove from Favorites"),
+			),
+			key.NewBinding(
+				key.WithKeys("R"),
+				key.WithHelp("R", "Refresh Playlists"),
+			),
+		}
+	}
 	if m.width > 0 && m.height > 0 {
 		m.playlistList.SetSize(m.width/2-4, m.height-4)
 	}


### PR DESCRIPTION
This adds the ability to easily add/remove favorites from your local favorites lists.

On any of the browse pages (artist, albums, playlists), you can now press `f` to add/remove the selected item from the Favorites menu. 

Using on the favorites menu you can trigger playback just like if you were on that item in the browser pages. IE you can use `enter` to play anything, and use `r` to play the radio if the selected favorite item is a artist. 

You can also add, delete and edit a favorite directly from the favorites menu with `a`, `d` and `e`

Items will show up in the browser with a `star` icon if they are currently favorites. 


<img width="643" height="554" alt="image" src="https://github.com/user-attachments/assets/16e48727-1249-46f4-bf2b-f67b6f78d4ed" />

<img width="647" height="565" alt="image" src="https://github.com/user-attachments/assets/5d7f8d9b-016d-46a1-85ff-9bdd672ccfb1" />

