### PR TITLE
Fix HTTPS server connections

### DIFF
--- a/internal/plex/plex-cloud-api.go
+++ b/internal/plex/plex-cloud-api.go
@@ -51,6 +51,7 @@ type PlexDeviceContainer struct {
 type PlexConnectionSelection struct {
 	Name             string `xml:"name,attr"`
 	ClientIdentifier string `xml:"clientIdentifier,attr"`
+	Scheme           string `xml:"scheme,attr"`
 	Address          string `xml:"address,attr"`
 	Local            string `xml:"local,attr"`
 	Port             string `xml:"port,attr"`
@@ -93,6 +94,7 @@ func (p *PlexClient) GetPlexServerInformation() ([]PlexConnectionSelection, erro
 			serverConnection := PlexConnectionSelection{
 				Name:             device.Name,
 				ClientIdentifier: device.ClientIdentifier,
+				Scheme:           connection.Protocol,
 				Address:          connection.Address,
 				Local:            connection.Local,
 				Port:             connection.Port,
@@ -141,6 +143,7 @@ func (p *PlexClient) GetPlexPlayers() ([]PlexConnectionSelection, error) {
 			serverConnection := PlexConnectionSelection{
 				Name:             device.Name,
 				ClientIdentifier: device.ClientIdentifier,
+				Scheme:           connection.Protocol,
 				Address:          connection.Address,
 				Local:            connection.Local,
 				Port:             connection.Port,

--- a/internal/plex/plex_local.go
+++ b/internal/plex/plex_local.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"plexamp-tui/internal/config"
 	"sort"
+	"strings"
 )
 
 // =====================
@@ -76,10 +77,20 @@ type PlexPlaylistContainer struct {
 // Library Fetching
 // =====================
 
+func buildPlexURL(serverAddr, path string) string {
+	addrLower := strings.ToLower(serverAddr)
+	if strings.HasPrefix(addrLower, "http://") || strings.HasPrefix(addrLower, "https://") {
+		return fmt.Sprintf("%s%s", strings.TrimRight(serverAddr, "/"), path)
+	}
+	return fmt.Sprintf("http://%s%s", serverAddr, path)
+}
+
 // FetchArtists retrieves all artists from the Plex library
 func (p *PlexClient) FetchArtists(serverAddr, libraryID, token string) ([]PlexArtist, error) {
-	urlStr := fmt.Sprintf("http://%s/library/sections/%s/all?type=8&X-Plex-Token=%s",
-		serverAddr, libraryID, url.QueryEscape(token))
+	urlStr := buildPlexURL(
+		serverAddr,
+		fmt.Sprintf("/library/sections/%s/all?type=8&X-Plex-Token=%s", libraryID, url.QueryEscape(token)),
+	)
 
 	p.logger.Debug(fmt.Sprintf("Fetching artists from: %s", urlStr))
 
@@ -129,8 +140,10 @@ func (p *PlexClient) FetchArtists(serverAddr, libraryID, token string) ([]PlexAr
 
 // FetchAlbums retrieves all albums from the Plex library
 func (p *PlexClient) FetchAlbums(serverAddr, libraryID, token string) ([]PlexAlbum, error) {
-	urlStr := fmt.Sprintf("http://%s/library/sections/%s/all?type=9&X-Plex-Token=%s",
-		serverAddr, libraryID, url.QueryEscape(token))
+	urlStr := buildPlexURL(
+		serverAddr,
+		fmt.Sprintf("/library/sections/%s/all?type=9&X-Plex-Token=%s", libraryID, url.QueryEscape(token)),
+	)
 
 	p.logger.Debug(fmt.Sprintf("Fetching albums from: %s", urlStr))
 
@@ -182,8 +195,10 @@ func (p *PlexClient) FetchAlbums(serverAddr, libraryID, token string) ([]PlexAlb
 
 // FetchArtistAlbums retrieves albums for a specific artist
 func (p *PlexClient) FetchArtistAlbums(serverAddr, artistRatingKey, token string) ([]PlexAlbum, error) {
-	urlStr := fmt.Sprintf("http://%s/library/metadata/%s/children?X-Plex-Token=%s",
-		serverAddr, artistRatingKey, url.QueryEscape(token))
+	urlStr := buildPlexURL(
+		serverAddr,
+		fmt.Sprintf("/library/metadata/%s/children?X-Plex-Token=%s", artistRatingKey, url.QueryEscape(token)),
+	)
 
 	p.logger.Debug(fmt.Sprintf("Fetching albums for artist %s from: %s", artistRatingKey, urlStr))
 
@@ -211,7 +226,10 @@ func (p *PlexClient) FetchArtistAlbums(serverAddr, artistRatingKey, token string
 }
 
 func (p *PlexClient) FetchPlaylists(serverAddr, token string) ([]PlexPlaylist, error) {
-	urlStr := fmt.Sprintf("http://%s/playlists?X-Plex-Token=%s", serverAddr, url.QueryEscape(token))
+	urlStr := buildPlexURL(
+		serverAddr,
+		fmt.Sprintf("/playlists?X-Plex-Token=%s", url.QueryEscape(token)),
+	)
 
 	p.logger.Debug(fmt.Sprintf("Fetching playlists from: %s", urlStr))
 
@@ -240,7 +258,10 @@ func (p *PlexClient) FetchPlaylists(serverAddr, token string) ([]PlexPlaylist, e
 
 func (p *PlexClient) FetchLibrary(serverAddr string) ([]config.PlexLibrary, error) {
 	token := p.GetPlexToken()
-	urlStr := fmt.Sprintf("http://%s/library/sections?X-Plex-Token=%s", serverAddr, url.QueryEscape(token))
+	urlStr := buildPlexURL(
+		serverAddr,
+		fmt.Sprintf("/library/sections?X-Plex-Token=%s", url.QueryEscape(token)),
+	)
 
 	p.logger.Debug(fmt.Sprintf("Fetching library from: %s", urlStr))
 

--- a/internal/ui/base.go
+++ b/internal/ui/base.go
@@ -237,7 +237,11 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		if msg.success {
 			m.config.ServerID = msg.server.clientIdentifier
-			m.config.PlexServerAddr = msg.server.address + ":" + msg.server.port
+			serverAddr := msg.server.address + ":" + msg.server.port
+			if msg.server.scheme != "" {
+				serverAddr = msg.server.scheme + "://" + serverAddr
+			}
+			m.config.PlexServerAddr = serverAddr
 			m.config.PlexServerName = msg.server.title
 			m.config.PlexLibraries = msg.libraries
 

--- a/internal/ui/plex_server_browse.go
+++ b/internal/ui/plex_server_browse.go
@@ -13,6 +13,7 @@ import (
 type serverItem struct {
 	title            string
 	clientIdentifier string
+	scheme           string
 	address          string
 	local            string
 	port             string
@@ -108,7 +109,11 @@ func (m *model) selectServerCmd(server serverItem) tea.Cmd {
 
 	return func() tea.Msg {
 
-		libraries, err := plexClient.FetchLibrary(fmt.Sprintf("%s:%s", server.address, server.port))
+		serverAddr := fmt.Sprintf("%s:%s", server.address, server.port)
+		if server.scheme != "" {
+			serverAddr = fmt.Sprintf("%s://%s", server.scheme, serverAddr)
+		}
+		libraries, err := plexClient.FetchLibrary(serverAddr)
 		log.Debug(fmt.Sprintf("Fetched libraries: %v", libraries))
 
 		if err != nil {
@@ -184,6 +189,7 @@ func (m *model) handleServerBrowseUpdate(msg tea.Msg) (tea.Model, tea.Cmd) {
 			items = append(items, serverItem{
 				title:            server.Name,
 				clientIdentifier: server.ClientIdentifier,
+				scheme:           server.Scheme,
 				address:          server.Address,
 				local:            server.Local,
 				port:             server.Port,


### PR DESCRIPTION
# Fix HTTPS server connections

Hey there! I finally found a moment to really look at the problem I was experiencing in https://github.com/spiercey/plexamp-tui/issues/12. As I expected, it does relate to my fairly niche setup: I serve Plex via HTTPS, and while the server browser could fetch the server list and handles the port number correctly, it wasn't tracking the scheme. The libraries request was being sent out insecurely to a secure socket, resulting in an empty response and a failure to load libraries.

The fix was (seemingly) pretty manageable, though I should warn you I'm just getting started with Go. 😅 

## Summary

- Capture connection scheme (http/https) from cloud API responses and propagate through server selection
- Build Plex URLs with the correct scheme instead of forcing http
- Update UI to store/use scheme-aware addresses when selecting servers and fetching libraries

## Changes

- `internal/plex/plex-cloud-api.go`: Store connection `scheme` on connection selections
- `internal/plex/plex_local.go`: Add `buildPlexURL` helper, reused for library, artist, album, and playlist requests
- `internal/ui/base.go`: Persist scheme-aware server address in config
- `internal/ui/plex_server_browse.go`: Carry scheme through server and library fetches
